### PR TITLE
Return css url

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var loadCss = require('./css');
+var getCssPath = require('./css');
 var bodyStyles = require('./bodyStyles');
 
 require('./jquery.modal.js');
 
-loadCss(window);
 bodyStyles(window);
 
 // return a function so that it can be used platform-independent as a factory
 // even though it's not an actual factory in the browser.
 module.exports = function () {};
+
+module.exports.css = getCssPath;

--- a/css.js
+++ b/css.js
@@ -1,16 +1,5 @@
 'use strict';
 
-var fs = require('fs');
-
-var insertCssFactory = function ($) {
-  return function (css) {
-    return $('<style/>').html(css).appendTo('head');
-  };
-};
-
-module.exports = function (window) {
-  var $ = window.jQuery;
-  var insertCss = insertCssFactory($);
-  var css = fs.readFileSync(__dirname + '/jquery.modal.css', 'utf8');
-  insertCss(css);
+module.exports = function () {
+  return __dirname + '/jquery.modal.css';
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var loadCss = require('./css');
+var getCssPath = require('./css');
 var bodyStyles = require('./bodyStyles');
 var sandbox = require('sandboxed-module');
 
@@ -8,6 +8,7 @@ module.exports = function (window) {
   sandbox.require('./jquery.modal.js', {
     globals: window
   });
-  loadCss(window);
   bodyStyles(window);
 };
+
+module.exports.css = getCssPath;


### PR DESCRIPTION
don't force css to be loaded in the document anymore, instead return a method with the path to the file.
